### PR TITLE
Add german slack channel and maintainer

### DIFF
--- a/README-de.md
+++ b/README-de.md
@@ -21,14 +21,11 @@ Weitere Informationen zum Beitrag zur Kubernetes-Dokumentation finden Sie unter:
 
 ## `README.md`'s Localizing Kubernetes Documentation
 
-### Koreanisch
+### Deutsch
+Die Betreuer der deutschen Lokalisierung erreichen Sie unter:
 
-Lesen Sie die Übersetzung von `README.md` und detailliertere Anleitungen für koreanische Mitwirkende auf der Seite [Koreanischen README](README-ko.md).
-
-Sie können die Betreuer der koreanischen Lokalisierung erreichen unter:
-
-* June Yi ([GitHub - @gochist](https://github.com/gochist))
-* [Slack Kanal](https://kubernetes.slack.com/messages/kubernetes-docs-ko)
+* Benedikt Rollik ([GitHub - @bene2k1](https://github.com/bene2k1))
+* [Slack Kanal](https://kubernetes.slack.com/messages/kubernetes-docs-de)
 
 ## Site lokal mit Docker ausführen
 


### PR DESCRIPTION
The german documentation should point to the german maintainer and slack channel and not to the korean one. I don't think that there are that many koreans reading the german documentation :-)